### PR TITLE
Use `bitcode::Buffer` in benchmark, mirroring `fastbuf::Buffer`.

### DIFF
--- a/benches/sandbox.rs
+++ b/benches/sandbox.rs
@@ -122,19 +122,21 @@ fn main() {
 
 #[bench(sample_count = 1000, sample_size = 1000)]
 fn bitcode_encode(bencher: Bencher) {
+    let mut buf = bitcode::Buffer::default();
     let model = model();
     bencher.bench_local(|| {
-        black_box(&bitcode::encode(&model));
+        black_box(&buf.encode(&model));
     });
 }
 
 #[bench(sample_count = 1000, sample_size = 1000)]
 fn bitcode_decode(bencher: Bencher) {
+    let mut buf = bitcode::Buffer::default();
     let model = model();
     let bytes = bitcode::encode(&model);
     let bytes = &bytes;
     bencher.bench_local(|| {
-        black_box(&bitcode::decode::<Model>(bytes).unwrap());
+        black_box(&buf.decode::<Model>(bytes).unwrap());
     });
 }
 


### PR DESCRIPTION
## Motivation
`fastbuf::Buffer` is being used for `serialization`:
https://github.com/Bruce0203/serialization/blob/3a3d1c9a7598cdae483925fff1f259202837fdcb/benches/sandbox.rs#L97

In the interest of fairness, `bitcode::Buffer` should be used too :)

## Before
```
├─ bitcode_decode  1.723 µs      │ 3.817 µs      │ 1.732 µs      │ 1.78 µs       │ 1000    │ 1000000
├─ bitcode_encode  850 ns        │ 1.999 µs      │ 851.8 ns      │ 863 ns        │ 1000    │ 1000000
├─ decode          1.515 µs      │ 3.914 µs      │ 1.525 µs      │ 1.591 µs      │ 1000    │ 1000000
╰─ encode          528.5 ns      │ 1.94 µs       │ 531.7 ns      │ 559.3 ns      │ 1000    │ 1000000
```

## After
```
├─ bitcode_decode  1.348 µs      │ 3.138 µs      │ 1.356 µs      │ 1.423 µs      │ 1000    │ 1000000
├─ bitcode_encode  351 ns        │ 768.7 ns      │ 366.8 ns      │ 372.1 ns      │ 1000    │ 1000000
├─ decode          1.511 µs      │ 3.943 µs      │ 1.532 µs      │ 1.611 µs      │ 1000    │ 1000000
╰─ encode          518.3 ns      │ 2.119 µs      │ 525.1 ns      │ 565 ns        │ 1000    │ 1000000
```